### PR TITLE
Hardware module

### DIFF
--- a/src/hardware/memory.rs
+++ b/src/hardware/memory.rs
@@ -1,0 +1,5 @@
+//set memory size
+pub const MEMORY_SIZE: usize = std::u16::MAX as usize;
+pub struct Memory {
+    pub cells: [u16; MEMORY_SIZE],
+}

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -1,0 +1,3 @@
+pub mod memory;
+pub mod opcode;
+pub mod register;

--- a/src/hardware/opcode.rs
+++ b/src/hardware/opcode.rs
@@ -1,0 +1,66 @@
+#[derive(PartialEq, Debug)]
+pub enum OpCode {
+    OpBr,   // branch
+    OpAdd,  // add
+    OpLd,   // load
+    OpSt,   // store
+    OpJsr,  // jump register
+    OpAnd,  // bitwise and
+    OpLdr,  // load register
+    OpStr,  // store register
+    OpRti,  // unused
+    OpNot,  // bitwise not
+    OpLdi,  // load indirect
+    OpSti,  // store indirect
+    OpJmp,  // jump
+    OpRes,  // reserved (unused)
+    OpLea,  // load effective address
+    OpTrap, // execute trap
+}
+impl OpCode {
+    pub fn get_op_code(op_code: u16) -> Option<OpCode> {
+        match op_code {
+            0 => Some(OpCode::OpBr),
+            1 => Some(OpCode::OpAdd),
+            2 => Some(OpCode::OpLd),
+            3 => Some(OpCode::OpSt),
+            4 => Some(OpCode::OpJsr),
+            5 => Some(OpCode::OpAnd),
+            6 => Some(OpCode::OpLdr),
+            7 => Some(OpCode::OpStr),
+            8 => Some(OpCode::OpRti),
+            9 => Some(OpCode::OpNot),
+            10 => Some(OpCode::OpLdi),
+            11 => Some(OpCode::OpSti),
+            12 => Some(OpCode::OpJmp),
+            13 => Some(OpCode::OpRes),
+            14 => Some(OpCode::OpLea),
+            15 => Some(OpCode::OpTrap),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod op_code_test {
+    use super::*;
+    #[test]
+    fn op_codes_initial_values() {
+        assert_eq!(Some(OpCode::OpBr), OpCode::get_op_code(0));
+        assert_eq!(Some(OpCode::OpAdd), OpCode::get_op_code(1));
+        assert_eq!(Some(OpCode::OpLd), OpCode::get_op_code(2));
+        assert_eq!(Some(OpCode::OpSt), OpCode::get_op_code(3));
+        assert_eq!(Some(OpCode::OpJsr), OpCode::get_op_code(4));
+        assert_eq!(Some(OpCode::OpAnd), OpCode::get_op_code(5));
+        assert_eq!(Some(OpCode::OpLdr), OpCode::get_op_code(6));
+        assert_eq!(Some(OpCode::OpStr), OpCode::get_op_code(7));
+        assert_eq!(Some(OpCode::OpRti), OpCode::get_op_code(8));
+        assert_eq!(Some(OpCode::OpNot), OpCode::get_op_code(9));
+        assert_eq!(Some(OpCode::OpLdi), OpCode::get_op_code(10));
+        assert_eq!(Some(OpCode::OpSti), OpCode::get_op_code(11));
+        assert_eq!(Some(OpCode::OpJmp), OpCode::get_op_code(12));
+        assert_eq!(Some(OpCode::OpRes), OpCode::get_op_code(13));
+        assert_eq!(Some(OpCode::OpLea), OpCode::get_op_code(14));
+        assert_eq!(Some(OpCode::OpTrap), OpCode::get_op_code(15));
+    }
+}

--- a/src/hardware/register.rs
+++ b/src/hardware/register.rs
@@ -1,0 +1,77 @@
+//set initial value of the program counter = 0x3000
+pub const PC_START: u16 = 0x3000;
+#[derive(Debug)]
+pub struct Registers {
+    pub r_01: u16,   // general purpose register
+    pub r_02: u16,   // general purpose register
+    pub r_03: u16,   // general purpose register
+    pub r_04: u16,   // general purpose register
+    pub r_05: u16,   // general purpose register
+    pub r_06: u16,   // general purpose register
+    pub r_07: u16,   // general purpose register
+    pub r_pc: u16,   // program counter
+    pub r_cond: u16, // condition flag
+}
+
+impl Registers {
+    pub fn new() -> Registers {
+        Registers {
+            r_01: 0,        // general purpose register
+            r_02: 0,        // general purpose register
+            r_03: 0,        // general purpose register
+            r_04: 0,        // general purpose register
+            r_05: 0,        // general purpose register
+            r_06: 0,        // general purpose register
+            r_07: 0,        // general purpose register
+            r_pc: PC_START, // program counter
+            r_cond: 0,      // condition flag
+        }
+    }
+}
+
+// The R_COND register stores condition flags which provide information
+// about the most recently executed calculation.
+// This allows programs to check logical conditions such as if (x > 0) { ... }.
+// The LC-3 uses only 3 condition flags
+// which indicate the sign of the previous calculation.
+pub enum ConditionFlag {
+    FlPos, // = 1, Positive
+    FlZro, // = 2, Zero
+    FlNeg, // = 4, Negative
+}
+
+pub fn get_flag_value(flag: ConditionFlag) -> u8 {
+    match flag {
+        ConditionFlag::FlPos => 1 << 0, // Positive
+        ConditionFlag::FlZro => 1 << 1, // Zero
+        ConditionFlag::FlNeg => 1 << 2, // Negative
+    }
+}
+
+#[cfg(test)]
+mod registers_test {
+    use super::*;
+    #[test]
+    fn value_of_r_pc_in_a_new_register_should_be_0x3000() {
+        let registers = Registers::new();
+        assert_eq!(0x3000, registers.r_pc);
+    }
+}
+
+#[cfg(test)]
+mod condition_flag_test {
+    use super::*;
+    #[test]
+    fn value_of_flpos_should_be_1() {
+        assert_eq!(1, get_flag_value(ConditionFlag::FlPos));
+    }
+    #[test]
+    fn value_of_flzro_should_be_2() {
+        assert_eq!(2, get_flag_value(ConditionFlag::FlZro));
+    }
+
+    #[test]
+    fn value_of_flneg_should_be_4() {
+        assert_eq!(4, get_flag_value(ConditionFlag::FlNeg));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,58 @@
 pub mod hardware;
-// use crate::hardware::Memory;
-// use crate::hardware::OpCode;
-// use crate::hardware::PC_START;
-//
-// fn run(memory: Memory) {
-//     //loop through memory from PC_START to end of the memory.
-//     let mut pc_pointer = PC_START as usize;
-//     loop {
-//         //get instruction from the current position
-//         let instruction = memory.instructions[pc_pointer];
-//         //extract op_code and run operation...
-//         match_and_perform_op(&instruction);
-//         //increment pointer
-//         pc_pointer += 1;
-//     }
-// }
+use self::hardware::memory::Memory;
+use self::hardware::opcode::OpCode;
+use self::hardware::register::PC_START;
 
-// fn match_and_perform_op(instruction: &u16) {
-//     //extract op_code from the instruction
-//     let op_code = extract_op_code(&instruction);
-//     //match and perform operation
-//     match op_code {
-//         Some(OpCode::op_add) => {}
-//         // Some(OpCode::op_and) => {}
-//         // Some(OpCode::op_not) => {}
-//         // Some(OpCode::op_br) => {}
-//         // Some(OpCode::op_jmp) => {}
-//         // Some(OpCode::op_jsr) => {}
-//         // Some(OpCode::op_ld) => {}
-//         // Some(OpCode::op_ldi) => {}
-//         // Some(OpCode::op_ldr) => {}
-//         // Some(OpCode::op_lea) => {}
-//         // Some(OpCode::op_st) => {}
-//         // Some(OpCode::op_sti) => {}
-//         // Some(OpCode::op_str) => {}
-//         Some(OpCode::op_trap) => {}
-//         _ => {}
-//     }
-// }
-//
-// fn extract_op_code(instruction: &u16) -> Option<OpCode> {
-//     OpCode::get_op_code(instruction >> 12)
-// }
-//
-// #[cfg(test)]
-// mod extract_op_code_test {
-//     use super::*;
-//     #[test]
-//     fn extract_test() {
-//         let four = 16384;
-//         assert_eq!(Some(OpCode::op_jsr), extract_op_code(&four));
-//     }
-// }
+pub fn run(memory: Memory) {
+    //loop through memory from PC_START to end of the memory.
+    let mut pc_pointer = PC_START as usize;
+    loop {
+        //get instruction from the current position
+        let instruction = memory.cells[pc_pointer];
+        //extract op_code and run operation...
+        match_and_perform_op(&instruction);
+        //increment pointer
+        pc_pointer += 1;
+    }
+}
+
+fn match_and_perform_op(instruction: &u16) {
+    //extract op_code from the instruction
+    let op_code = extract_op_code(&instruction);
+    //match and perform operation
+    match op_code {
+        Some(OpCode::OpAdd) => {}
+        // Some(OpCode::op_and) => {}
+        // Some(OpCode::op_not) => {}
+        // Some(OpCode::op_br) => {}
+        // Some(OpCode::op_jmp) => {}
+        // Some(OpCode::op_jsr) => {}
+        // Some(OpCode::op_ld) => {}
+        // Some(OpCode::op_ldi) => {}
+        // Some(OpCode::op_ldr) => {}
+        // Some(OpCode::op_lea) => {}
+        // Some(OpCode::op_st) => {}
+        // Some(OpCode::op_sti) => {}
+        // Some(OpCode::op_str) => {}
+        //Some(OpCode::OpTrap) => {}
+        _ => {}
+    }
+}
+
+//Each instruction is 16 bits long, with the left 4 bits storing the opcode.
+//The rest of the bits are used to store the parameters.
+//To extract left 4 bits out of the instruction, we'll use ">>" shift-right
+//operator and shift first 4 bits 12 positions towards right
+fn extract_op_code(instruction: &u16) -> Option<OpCode> {
+    OpCode::get_op_code(instruction >> 12)
+}
+
+#[cfg(test)]
+mod extract_op_code_test {
+    use super::*;
+    #[test]
+    fn extract_test() {
+        let four = 16384;
+        assert_eq!(Some(OpCode::OpJsr), extract_op_code(&four));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,119 +1,54 @@
-mod hardware {
-    const MEMORY_SIZE: usize = std::u16::MAX as usize;
-    struct Memory {
-        location: [u16; MEMORY_SIZE],
-    }
+pub mod hardware;
+// use crate::hardware::Memory;
+// use crate::hardware::OpCode;
+// use crate::hardware::PC_START;
+//
+// fn run(memory: Memory) {
+//     //loop through memory from PC_START to end of the memory.
+//     let mut pc_pointer = PC_START as usize;
+//     loop {
+//         //get instruction from the current position
+//         let instruction = memory.instructions[pc_pointer];
+//         //extract op_code and run operation...
+//         match_and_perform_op(&instruction);
+//         //increment pointer
+//         pc_pointer += 1;
+//     }
+// }
 
-    struct Registers {
-        r_01: u16,   // general purpose register
-        r_02: u16,   // general purpose register
-        r_03: u16,   // general purpose register
-        r_04: u16,   // general purpose register
-        r_05: u16,   // general purpose register
-        r_06: u16,   // general purpose register
-        r_07: u16,   // general purpose register
-        r_pc: u16,   // program counter
-        r_cond: u16, // condition flag
-    }
-
-    struct OpCode {
-        op_br: u8,   // branch
-        op_add: u8,  // add
-        op_ld: u8,   // load
-        op_st: u8,   // store
-        op_jsr: u8,  // jump register
-        op_and: u8,  // bitwise and
-        op_ldr: u8,  // load register
-        op_str: u8,  // store register
-        op_rti: u8,  // unused
-        op_not: u8,  // bitwise not
-        op_ldi: u8,  // load indirect
-        op_sti: u8,  // store indirect
-        op_jmp: u8,  // jump
-        op_res: u8,  // reserved (unused)
-        op_lea: u8,  // load effective address
-        op_trap: u8, // execute trap
-    }
-
-    impl OpCode {
-        fn new() -> OpCode {
-            OpCode {
-                op_br: 0,    // branch
-                op_add: 1,   // add
-                op_ld: 2,    // load
-                op_st: 3,    // store
-                op_jsr: 4,   // jump register
-                op_and: 5,   // bitwise and
-                op_ldr: 6,   // load register
-                op_str: 7,   // store register
-                op_rti: 8,   // unused
-                op_not: 9,   // bitwise not
-                op_ldi: 10,  // load indirect
-                op_sti: 11,  // store indirect
-                op_jmp: 12,  // jump
-                op_res: 13,  // reserved (unused)
-                op_lea: 14,  // load effective address
-                op_trap: 15, // execute trap
-            }
-        }
-    }
-
-    enum ConditionFlag {
-        FlPos,
-        FlZro,
-        FlNeg,
-    }
-
-    fn get_flag_value(flag: ConditionFlag) -> u8 {
-        match flag {
-            ConditionFlag::FlPos => 1 << 0, // Positive
-            ConditionFlag::FlZro => 1 << 1, // Zero
-            ConditionFlag::FlNeg => 1 << 2, // Negative
-        }
-    }
-
-    #[cfg(test)]
-    mod condition_flag_test {
-        use super::*;
-        #[test]
-        fn value_of_FlPos_should_be_1() {
-            assert_eq!(1, get_flag_value(ConditionFlag::FlPos));
-        }
-        #[test]
-        fn value_of_FLZro_should_be_2() {
-            assert_eq!(2, get_flag_value(ConditionFlag::FlZro));
-        }
-
-        #[test]
-        fn value_of_FlNeg_should_be_4() {
-            assert_eq!(4, get_flag_value(ConditionFlag::FlNeg));
-        }
-
-    }
-
-    #[cfg(test)]
-    mod op_code_test {
-        use super::*;
-        #[test]
-        fn op_code_test() {
-            let op_codes = OpCode::new();
-            assert_eq!(0, op_codes.op_br);
-            assert_eq!(1, op_codes.op_add);
-            assert_eq!(2, op_codes.op_ld);
-            assert_eq!(3, op_codes.op_st);
-            assert_eq!(4, op_codes.op_jsr);
-            assert_eq!(5, op_codes.op_and);
-            assert_eq!(6, op_codes.op_ldr);
-            assert_eq!(7, op_codes.op_str);
-            assert_eq!(8, op_codes.op_rti);
-            assert_eq!(9, op_codes.op_not);
-            assert_eq!(10, op_codes.op_ldi);
-            assert_eq!(11, op_codes.op_sti);
-            assert_eq!(12, op_codes.op_jmp);
-            assert_eq!(13, op_codes.op_res);
-            assert_eq!(14, op_codes.op_lea);
-            assert_eq!(15, op_codes.op_trap);
-        }
-
-    }
-}
+// fn match_and_perform_op(instruction: &u16) {
+//     //extract op_code from the instruction
+//     let op_code = extract_op_code(&instruction);
+//     //match and perform operation
+//     match op_code {
+//         Some(OpCode::op_add) => {}
+//         // Some(OpCode::op_and) => {}
+//         // Some(OpCode::op_not) => {}
+//         // Some(OpCode::op_br) => {}
+//         // Some(OpCode::op_jmp) => {}
+//         // Some(OpCode::op_jsr) => {}
+//         // Some(OpCode::op_ld) => {}
+//         // Some(OpCode::op_ldi) => {}
+//         // Some(OpCode::op_ldr) => {}
+//         // Some(OpCode::op_lea) => {}
+//         // Some(OpCode::op_st) => {}
+//         // Some(OpCode::op_sti) => {}
+//         // Some(OpCode::op_str) => {}
+//         Some(OpCode::op_trap) => {}
+//         _ => {}
+//     }
+// }
+//
+// fn extract_op_code(instruction: &u16) -> Option<OpCode> {
+//     OpCode::get_op_code(instruction >> 12)
+// }
+//
+// #[cfg(test)]
+// mod extract_op_code_test {
+//     use super::*;
+//     #[test]
+//     fn extract_test() {
+//         let four = 16384;
+//         assert_eq!(Some(OpCode::op_jsr), extract_op_code(&four));
+//     }
+// }


### PR DESCRIPTION
Code refactored as follows.

- Added a top level folder named hardware. It will be serve as a top-level module to simulate LC-3 hardware.
- Created memory.rs, register.rs and opcode.rs to handle each in separate files. These files will serve as separate modules to represent different components of the hardware.
- In the crate lib.rs, also added an API  fn run(), to handle the VM work-flow, along with some helper functions.