### PR TITLE
Update deprecated constructs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::error::Error;
 use std::process;
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     //setup for interrupt handling.
     terminal::spawn_control_c_handler()?;
     //handle command line arguments and process instructions

--- a/src/sys/select.rs
+++ b/src/sys/select.rs
@@ -16,7 +16,7 @@ pub struct FdSet(libc::fd_set);
 
 impl FdSet {
     pub fn new() -> FdSet {
-        let mut fdset = unsafe { mem::uninitialized() };
+	let mut fdset = unsafe { mem::MaybeUninit::uninit().assume_init() };
         unsafe { libc::FD_ZERO(&mut fdset) };
         FdSet(fdset)
     }

--- a/src/sys/terminal.rs
+++ b/src/sys/terminal.rs
@@ -36,7 +36,7 @@ pub fn turn_off_canonical_and_echo_modes() {
 /// `spawn_control_c_handler` function will spawn a thread to handle `Control-C` (interrupt signal).
 /// When user presses `Control-C` keys, it restores terminal to its original, i.e. it turns value of `ICANON` and `ECHO` modes to 1.
 /// And exists the process with process code = 130 (as mentioned here, http://tldp.org/LDP/abs/html/exitcodes.html).
-pub fn spawn_control_c_handler() -> Result<(), Box<Error>> {
+pub fn spawn_control_c_handler() -> Result<(), Box<dyn Error>> {
     //setup for interrupt handling.
     let signals = Signals::new(&[SIGINT])?;
     thread::spawn(move || {


### PR DESCRIPTION
Add dyn keyword to Box objects and replace mem::uninitialize.