### PR TITLE
Fix memory size

### DIFF
--- a/src/hardware/memory/mod.rs
+++ b/src/hardware/memory/mod.rs
@@ -8,7 +8,7 @@ use crate::sys::time::TimeValLike;
 use libc::STDIN_FILENO;
 
 /// `MEMORY_SIZE` is a constant to represent size of memory in LC-3.
-pub const MEMORY_SIZE: usize = std::u16::MAX as usize;
+pub const MEMORY_SIZE: usize = u16::MAX as usize + 1;
 
 /// `Memory` : LC-3 has 65,536 memory locations (the maximum that is addressable by a 16-bit unsigned integer 2^16),
 /// each of which stores a 16-bit value. This means it can store a total of only 128kb.
@@ -68,5 +68,23 @@ fn check_key() -> bool {
     match select::select(1, &mut fd, None, None, &mut timeout) {
         Err(_) => false,
         _ => true,
+    }
+}
+
+#[cfg(test)]
+mod memory_test {
+    use super::*;
+
+    const EXPECTED_MEMORY_SIZE: usize = 65536;
+
+    #[test]
+    fn memory_size() {
+        let memory = Memory::new();
+        assert_eq!(memory.cells.len(), EXPECTED_MEMORY_SIZE);
+    }
+
+    #[test]
+    fn memory_size_constant() {
+        assert_eq!(MEMORY_SIZE, EXPECTED_MEMORY_SIZE);
     }
 }


### PR DESCRIPTION
# Summary

These changes ensure that there are precisely `65536` memory locations (`2^16`), which corresponds with the documentation and code comments. The issue is described in more detail below:

# The problem

Attempting to access the highest valid memory address (e.g. `mem.read(u16::MAX)`) results in a runtime panic:

```shell
thread 'main' panicked at 'index out of bounds: the len is 65535 but the index is 65535', src/hardware/memory/mod.rs:41:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because the `std::u16::MAX` constant is used as the size for the `cells` array in `Memory`:  

```rust
/// `MEMORY_SIZE` is a constant to represent size of memory in LC-3.
pub const MEMORY_SIZE: usize = std::u16::MAX as usize;

pub struct Memory {
    /// Memory is an array of `u16` cells, with length = 65,536.
    pub cells: [u16; MEMORY_SIZE],
}
```

According to the standard library documentation for [std::u16::MAX](https://doc.rust-lang.org/std/u16/constant.MAX.html), this is represented as:

> The largest value that can be represented by this integer type. 

As a result, `cells` will have a size of `65535`—for elements `0` through `65534`—one less memory location than expected. The number of memory locations also differs from the number specified in the documentation.

# Additional information

The `std::u16` constants are marked for [deprecation](https://doc.rust-lang.org/std/u16/index.html). Instead, the new associated constant [u16::MAX](https://doc.rust-lang.org/std/primitive.u16.html#associatedconstant.MAX) is used here.

----

Alternative expressions that would work equally well as a fix:

```rust
pub const MEMORY_SIZE: usize = 65536;
pub const MEMORY_SIZE: usize = 1 << u16::BITS as usize;
```
